### PR TITLE
change cbs storage name to be required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BUG FIXES:
+
+* resource/tencentcloud_cbs_storage: make name to be required ([#25](https://github.com/tencentyun/terraform-provider-tencentcloud/issues/25))
+
 ## v1.2.0 (April 3, 2018)
 
 FEATURES:

--- a/tencentcloud/resource_tc_cbs_storage.go
+++ b/tencentcloud/resource_tc_cbs_storage.go
@@ -85,7 +85,7 @@ func resourceTencentCloudCbsStorage() *schema.Resource {
 			},
 			"storage_name": &schema.Schema{
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validateStorageName,
 			},
 			"storage_status": &schema.Schema{

--- a/tencentcloud/validators.go
+++ b/tencentcloud/validators.go
@@ -25,7 +25,7 @@ func validateNameRegex(v interface{}, k string) (ws []string, errors []error) {
 func validateStorageType(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !goset.IsIncluded(availableStorageTypeFamilies, value) {
-		errors = append(errors, fmt.Errorf("not found instance_type_family: %v", value))
+		errors = append(errors, fmt.Errorf("Invalid storage type: %v. Valid choice: %s.", value, availableStorageTypeFamilies))
 	}
 	return
 }
@@ -33,7 +33,7 @@ func validateStorageType(v interface{}, k string) (ws []string, errors []error) 
 func validateStorageName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if value == "" {
-		return
+		errors = append(errors, fmt.Errorf("Storage name cannot be empty."))
 	}
 
 	if len(value) > MaxStorageNameLength {
@@ -217,9 +217,9 @@ func validateInstanceName(v interface{}, k string) (ws []string, errors []error)
 func validateAllowedStringValue(ss []string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (ws []string, errors []error) {
 		value := v.(string)
-        if !goset.IsIncluded(ss, value) {
+		if !goset.IsIncluded(ss, value) {
 			errors = append(errors, fmt.Errorf("%q must contain a valid string value should in array %#v, got %q", k, ss, value))
-        }
+		}
 		return
 	}
 }


### PR DESCRIPTION
If name is not specified, then cbs storage will have a default name,
which then cause endless update action which will never succeed.

Also fix a typo for cbs storage type validation.

fix: https://github.com/tencentyun/terraform-provider-tencentcloud/issues/25
fix: https://github.com/tencentyun/terraform-provider-tencentcloud/issues/24