### PR TITLE
correct vpc resource name in docs and add CLOUD_PREMIUM support

### DIFF
--- a/tencentcloud/resource_tc_instance.go
+++ b/tencentcloud/resource_tc_instance.go
@@ -29,10 +29,11 @@ const (
 )
 
 const (
-	tencentCloudApiDiskTypeLocalBaisc = "LOCAL_BASIC"
-	tencentCloudApiDiskTypeLocalSSD   = "LOCAL_SSD"
-	tencentCloudApiDiskTypeCloudBasic = "CLOUD_BASIC"
-	tencentCloudApiDiskTypeCloudSSD   = "CLOUD_SSD"
+	tencentCloudApiDiskTypeLocalBaisc   = "LOCAL_BASIC"
+	tencentCloudApiDiskTypeLocalSSD     = "LOCAL_SSD"
+	tencentCloudApiDiskTypeCloudBasic   = "CLOUD_BASIC"
+	tencentCloudApiDiskTypeCloudPremium = "CLOUD_PREMIUM"
+	tencentCloudApiDiskTypeCloudSSD     = "CLOUD_SSD"
 )
 
 var (
@@ -50,6 +51,7 @@ var (
 		tencentCloudApiDiskTypeLocalBaisc,
 		tencentCloudApiDiskTypeLocalSSD,
 		tencentCloudApiDiskTypeCloudBasic,
+		tencentCloudApiDiskTypeCloudPremium,
 		tencentCloudApiDiskTypeCloudSSD,
 	}
 	availableInstanceChargeTypePrePaidPeriodValues    = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 24, 36}

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -124,11 +124,11 @@ The following arguments are supported:
 
 * `security_groups` - (Optional)  A list of security group ids to associate with.
 
-* `system_disk_type` - (Optional) Valid values are `LOCAL_BASIC`, `LOCAL_SSD`,  `CLOUD_BASIC` and `CLOUD_SSD`.
+* `system_disk_type` - (Optional) Valid values are `LOCAL_BASIC`, `LOCAL_SSD`,  `CLOUD_BASIC`, `CLOUD_PREMIUM` and `CLOUD_SSD`.
 
 * `system_disk_size` - (Optional) Size of the system disk, value range: 50GB ~ 1TB. Default is 50GB.
 
-* `data_disks` - (Optional) Settings for data disk. In each disk, `data_disk_type` indicates the disk type, valid values are `LOCAL_BASIC`, `LOCAL_SSD`,  `CLOUD_BASIC` and `CLOUD_SSD`. **NOTE**, it must follow the system_disk_type, and all disks must be the same type. `data_disk_size` is the size of the data disk, value range: 60GB~1.6TB.
+* `data_disks` - (Optional) Settings for data disk. In each disk, `data_disk_type` indicates the disk type, valid values are `LOCAL_BASIC`, `LOCAL_SSD`,  `CLOUD_BASIC`, `CLOUD_PREMIUM` and `CLOUD_SSD`. **NOTE**, it must follow the system_disk_type, and all disks must be the same type. `data_disk_size` is the size of the data disk, value range: 60GB~1.6TB.
 
 * `disable_security_service` - (Optional) Disable enhance service for security, it is enabled by default. When this options is set, security agent won't be installed.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -19,7 +19,7 @@ resource "tencentcloud_subnet" "main" {
   name              = "my test subnet"
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-guangzhou-3"
-  vpc_id            = "${tencent_vpc.main.id}"
+  vpc_id            = "${tencentcloud_vpc.main.id}"
 }
 ```
 


### PR DESCRIPTION
1. Correct vpc resource name in docs
2. Add CLOUD_PREMIUM disk type support to instance resource
3. Based on 2, update docs accordingly